### PR TITLE
Fix warnings about using uninitialized variables

### DIFF
--- a/memstat.cpp
+++ b/memstat.cpp
@@ -46,12 +46,12 @@ MemStatPrivate::~MemStatPrivate()
 
 void MemStatPrivate::timeout()
 {
-    qulonglong memTotal;
-    qulonglong memFree;
-    qulonglong memBuffers;
-    qulonglong memCached;
-    qulonglong swapTotal;
-    qulonglong swapFree;
+    qulonglong memTotal = 0;
+    qulonglong memFree = 0;
+    qulonglong memBuffers = 0;
+    qulonglong memCached = 0;
+    qulonglong swapTotal = 0;
+    qulonglong swapFree = 0;
 
     foreach (QString row, readAllFile("/proc/meminfo").split(QChar('\n'), QString::SkipEmptyParts))
     {


### PR DESCRIPTION
Six warnings were given when compiling. Initializing the local variables fixed them. It also fixed possibly emitting updates calculated by using undefined values of the variables if reading from /proc/meminfo failed.