### PR TITLE
Fix rare file descriptor leak in readAllFile()

### DIFF
--- a/basestat.cpp
+++ b/basestat.cpp
@@ -122,7 +122,7 @@ QString BaseStatPrivate::readAllFile(const char *filename)
     static char buffer[bufferSize];
 
     int fd = ::open(filename, O_RDONLY);
-    if (fd > 0)
+    if (fd > -1)
     {
         ssize_t size = ::read(fd, buffer, bufferSize);
         ::close(fd);


### PR DESCRIPTION
If open() returned the valid file descriptor 0 then it was handled like an error. The file was therefore neither read nor closed which leaked the file descriptor and made the function just return an empty string.

Thanks.
